### PR TITLE
Updated ES6 Lottie Import Statement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -205,7 +205,7 @@ npm install --save @lottiefiles/jlottie
 2. Import package in your code.
 
 ```javascript
-import jlottie from '@lottiefiles/jlottie';
+import * as jlottie from '@lottiefiles/jlottie';
 ```
 
 OR


### PR DESCRIPTION
The version currently served from npm does not work if the provided ES6 import statement is used, changing it to `import * as jlottie from '@lottiefiles/jlottie';` fixes the issue.