### PR TITLE
Add small perf enhancements for requestAnimationFrame, will-change & paint containment

### DIFF
--- a/src/jlottie.js
+++ b/src/jlottie.js
@@ -359,7 +359,9 @@ export function lottiemate() {
     }
       
   }
-  setTimeout(lottiemate, smallestFrameTime - (postRender - currentDate));
+  setTimeout(() => {
+    requestAnimationFrame(lottiemate);
+  }, smallestFrameTime - 16 /* 1 animation frame */ - (postRender - currentDate));
 }
 
 /// ////////// BUILD SCENE GRAPH
@@ -2313,6 +2315,7 @@ export function getLayers(elementId, animationId, elementObj, passedObj, passedK
         newTranslateGroup = document.createElementNS(xmlns, 'g');
         newTranslateGroup.setAttribute('id', `${animationId}_${depth}_layerTranslate${passedObj[passedKey][i]._layer}`);
         newTranslateGroup.setAttribute('opacity', 1);
+        newTranslateGroup.setAttribute('style', 'will-change:transform');
         newLayer.prepend(newTranslateGroup);
         if (passedObj[passedKey][i].w > 0) {
           newLayer.style.width = passedObj[passedKey][i].w;
@@ -2742,6 +2745,7 @@ export function buildGraph(elementId, animationId, elementObj, autoplay, loop, c
     // newSVG.setAttributeNS(null, 'height', animation[animationId].h);
     newSVG.setAttributeNS(null, 'viewBox', `0 0 ${animation[animationId].w} ${animation[animationId].h}`);
     newSVG.setAttributeNS(null, 'preserveAspectRatio', 'xMidYMid meet');
+    newSVG.style.contain = 'paint size layout';
     newSVG.style.width = '100%';
     newSVG.style.height = '100%';
     newSVG.setAttributeNS(null, 'id', `_svg${animationId}`);

--- a/src/jlottie.js
+++ b/src/jlottie.js
@@ -635,13 +635,13 @@ export function addGroupPositionTransform(
       .getElementById(transforms.refObj)
       .getBoundingClientRect().height;
   }
-  if (objectId._layer == 3) {
-    console.log(
-      `ORIGINAL: ${animation[animationId]._objSize[transforms.refObj][0]}, ${
-        animation[animationId]._objSize[transforms.refObj][1]
-      } // ${transforms.anchorX}, ${transforms.anchorY}`,
-    );
-  }
+  // if (objectId._layer == 3) {
+  //   console.log(
+  //     `ORIGINAL: ${animation[animationId]._objSize[transforms.refObj][0]}, ${
+  //       animation[animationId]._objSize[transforms.refObj][1]
+  //     } // ${transforms.anchorX}, ${transforms.anchorY}`,
+  //   );
+  // }
   transforms.refObjSet = true;
 
   let posY = 0;
@@ -2315,7 +2315,6 @@ export function getLayers(elementId, animationId, elementObj, passedObj, passedK
         newTranslateGroup = document.createElementNS(xmlns, 'g');
         newTranslateGroup.setAttribute('id', `${animationId}_${depth}_layerTranslate${passedObj[passedKey][i]._layer}`);
         newTranslateGroup.setAttribute('opacity', 1);
-        newTranslateGroup.setAttribute('style', 'will-change:transform');
         newLayer.prepend(newTranslateGroup);
         if (passedObj[passedKey][i].w > 0) {
           newLayer.style.width = passedObj[passedKey][i].w;
@@ -3011,7 +3010,7 @@ export function goToAndStop(_frame, isFrame, name) {
       if (animation[i]._elementId == name || animation[i]._customName == name) {
         animation[i]._paused = true;
         animation[i]._currentFrame = _frame;
-        console.log(`${name} == ${_frame}`);
+        // console.log(`${name} == ${_frame}`);
         loadFrame(i, _frame);
         break;
       }

--- a/src/jlottie.js
+++ b/src/jlottie.js
@@ -635,13 +635,13 @@ export function addGroupPositionTransform(
       .getElementById(transforms.refObj)
       .getBoundingClientRect().height;
   }
-  // if (objectId._layer == 3) {
-  //   console.log(
-  //     `ORIGINAL: ${animation[animationId]._objSize[transforms.refObj][0]}, ${
-  //       animation[animationId]._objSize[transforms.refObj][1]
-  //     } // ${transforms.anchorX}, ${transforms.anchorY}`,
-  //   );
-  // }
+  if (objectId._layer == 3) {
+    console.log(
+      `ORIGINAL: ${animation[animationId]._objSize[transforms.refObj][0]}, ${
+        animation[animationId]._objSize[transforms.refObj][1]
+      } // ${transforms.anchorX}, ${transforms.anchorY}`,
+    );
+  }
   transforms.refObjSet = true;
 
   let posY = 0;
@@ -3010,7 +3010,7 @@ export function goToAndStop(_frame, isFrame, name) {
       if (animation[i]._elementId == name || animation[i]._customName == name) {
         animation[i]._paused = true;
         animation[i]._currentFrame = _frame;
-        // console.log(`${name} == ${_frame}`);
+        console.log(`${name} == ${_frame}`);
         loadFrame(i, _frame);
         break;
       }

--- a/src/jlottie.js
+++ b/src/jlottie.js
@@ -2745,7 +2745,7 @@ export function buildGraph(elementId, animationId, elementObj, autoplay, loop, c
     // newSVG.setAttributeNS(null, 'height', animation[animationId].h);
     newSVG.setAttributeNS(null, 'viewBox', `0 0 ${animation[animationId].w} ${animation[animationId].h}`);
     newSVG.setAttributeNS(null, 'preserveAspectRatio', 'xMidYMid meet');
-    newSVG.style.contain = 'paint size layout';
+    newSVG.style.contain = 'strict';
     newSVG.style.width = '100%';
     newSVG.style.height = '100%';
     newSVG.setAttributeNS(null, 'id', `_svg${animationId}`);


### PR DESCRIPTION
I added a few small perf enhancements and then tested locally against the original version and this with a few different animations. The before / after from Chrome's performance tests are below:

### Before
<img width="1013" alt="Screen Shot 2021-09-20 at 4 26 49 PM" src="https://user-images.githubusercontent.com/23196205/134089984-b2b50378-33f0-4f3d-a694-1e2429db3f10.png">

### After
<img width="1010" alt="Screen Shot 2021-09-20 at 4 27 05 PM" src="https://user-images.githubusercontent.com/23196205/134090000-f39f1094-d80a-4d77-a77f-b6138bcbedb4.png">

https://user-images.githubusercontent.com/23196205/134090132-0a631fe5-1302-4cb9-819d-601b1cc6738f.mp4

It might be interesting to re-run your benchmarks if this lands.